### PR TITLE
Bit Board Revamp

### DIFF
--- a/perft
+++ b/perft
@@ -15,7 +15,11 @@ if ! [[ "$1" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-gcc -g -o perftTesting testing/perft.c testing/logChessStructs.c src/chessGameEmulator.c src/moveGenerator.c src/utils/fenString.c src/utils/utils.c src/state/board.c src/state/gameState.c src/state/move.c src/state/piece.c src/magicBitBoard/magicBitBoard.c src/magicBitBoard/rook.c src/magicBitBoard/bishop.c 
+gcc -Wall -Wextra -Werror -Wunused -g -o perftTesting testing/perft.c testing/logChessStructs.c src/chessGameEmulator.c src/moveGenerator.c src/utils/fenString.c src/utils/utils.c src/state/board.c src/state/gameState.c src/state/move.c src/state/piece.c src/magicBitBoard/magicBitBoard.c src/magicBitBoard/rook.c src/magicBitBoard/bishop.c 
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
 
 if [ "$#" -eq 3 ]; then
     ./perftTesting "$1" "$2" "$3"

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -9,6 +9,6 @@
  * Returns the valid moves in a given position
  * The results array is assumed to be 0 initialized
 */
-void getValidMoves(Move results[MAX_LEGAL_MOVES + 1], const GameState currentState, const GameState* previousStates);
+void getValidMoves(Move results[MAX_LEGAL_MOVES + 1], const GameState currentGameState, const GameState* previousStates);
 
 #endif

--- a/src/magicBitBoard/bishop.c
+++ b/src/magicBitBoard/bishop.c
@@ -79,7 +79,7 @@ u64 bishopPseudoLegalMovesBitBoardFromBlockingBitBoard(int position, u64 blockin
     return result;
 }
 
-static inline u64 generateBlockingBitBoardFromIndex(int position, int index, int nbValidSquareForPiece, u64 movementMask) {
+static inline u64 generateBlockingBitBoardFromIndex(int index, int nbValidSquareForPiece, u64 movementMask) {
     u64 result = (u64) 0;
     for (int i = 0; i < nbValidSquareForPiece; i++) {
         u64 bitToShift = (u64) ((index >> i) & 1);
@@ -95,7 +95,7 @@ void fillBishopBlockingBitBoardAndPseudoLegalMoveArray(int position, u64* blocki
     int nbBlockingBitBoard = 1 << nbValidSquareForBishop;
     u64 movementMask = bishopMovementMaskFromPosition(position);
     for (int i = 0; i < nbBlockingBitBoard; i++) {
-        blockingBitBoards[i] = generateBlockingBitBoardFromIndex(position, i, nbValidSquareForBishop, movementMask);
+        blockingBitBoards[i] = generateBlockingBitBoardFromIndex(i, nbValidSquareForBishop, movementMask);
         blockingBitBoardToPseudoLegalmoves[i] = bishopPseudoLegalMovesBitBoardFromBlockingBitBoard(position, blockingBitBoards[i]);
     }
 }

--- a/src/magicBitBoard/magicBitBoard.c
+++ b/src/magicBitBoard/magicBitBoard.c
@@ -63,8 +63,6 @@ void magicBitBoardInitialize() {
             u64 key = (blockingBitBoard * magic) >> shift;
             u64 indexIntoPseudoLegalMovesArray = offset + key;
 
-            u64 nextIndex = position == 63 ? ROOK_PSEUDO_LEGAL_MOVES_ARRAY_SIZE : rookIndexOffset[position + 1];
-
             rookPseudoLegalMovesBitBoard[indexIntoPseudoLegalMovesArray] = pseudoLegalMovesBitBoard;
         }
     }

--- a/src/magicBitBoard/rook.c
+++ b/src/magicBitBoard/rook.c
@@ -77,7 +77,7 @@ u64 rookPseudoLegalMovesBitBoardFromBlockingBitBoard(int position, u64 blockingB
     return result;
 }
 
-static inline u64 generateBlockingBitBoardFromIndex(int position, int index, int nbValidSquareForPiece, u64 movementMask) {
+static inline u64 generateBlockingBitBoardFromIndex(int index, int nbValidSquareForPiece, u64 movementMask) {
     u64 result = (u64) 0;
     for (int i = 0; i < nbValidSquareForPiece; i++) {
         u64 bitToShift = (u64) ((index >> i) & 1);
@@ -93,7 +93,7 @@ void fillRookBlockingBitBoardAndPseudoLegalMoveArray(int position, u64* blocking
     u64 movementMask = rookMovementMaskFromPosition(position);
     int nbBlockingBitBoard = 1 << nbValidSquareForRook;
     for (int i = 0; i < nbBlockingBitBoard; i++) {
-        blockingBitBoards[i] = generateBlockingBitBoardFromIndex(position, i, nbValidSquareForRook, movementMask);
+        blockingBitBoards[i] = generateBlockingBitBoardFromIndex(i, nbValidSquareForRook, movementMask);
         blockingBitBoardToPseudoLegalmoves[i] = rookPseudoLegalMovesBitBoardFromBlockingBitBoard(position, blockingBitBoards[i]);;
     }
 }

--- a/src/moveGenerator.c
+++ b/src/moveGenerator.c
@@ -274,7 +274,7 @@ void getKingMoves(int currentIndex, int result[BOARD_LENGTH]) {
     if (currentIndex % 8 != 7 && currentIndex / 8 != 7) { result[counter++] = currentIndex + 9; }
 }
 
-bool isIndexPseudoLegalForKnight(GameState currentState, int currentIndex, int targetSquare, bool goDownOne) {
+bool isIndexPseudoLegalForKnight(int currentIndex, int targetSquare, bool goDownOne) {
     int y = targetSquare / 8;
     bool wrappingCondition = (goDownOne) ? 
         abs(currentIndex / 8 - y) == 1 : 
@@ -283,17 +283,17 @@ bool isIndexPseudoLegalForKnight(GameState currentState, int currentIndex, int t
     return pieceColor(pieceAtIndex(currentState.board, targetSquare)) != currentState.colorToGo;
 }
 
-void getKnightPseudoLegalMoves(GameState currentState, int currentIndex, int result[BOARD_LENGTH]) {
+void getKnightPseudoLegalMoves(int currentIndex, int result[BOARD_LENGTH]) {
     int counter = 0;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex - 6 , true )) result[counter++] = currentIndex - 6 ;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex - 15, false)) result[counter++] = currentIndex - 15;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex - 10, true )) result[counter++] = currentIndex - 10;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex - 17, false)) result[counter++] = currentIndex - 17;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex + 6 , true )) result[counter++] = currentIndex + 6 ;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex + 10, true )) result[counter++] = currentIndex + 10;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex + 15, false)) result[counter++] = currentIndex + 15;
-    if (isIndexPseudoLegalForKnight(currentState, currentIndex, currentIndex + 17, false)) result[counter++] = currentIndex + 17;
-} 
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex - 6 , true )) result[counter++] = currentIndex - 6 ;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex - 15, false)) result[counter++] = currentIndex - 15;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex - 10, true )) result[counter++] = currentIndex - 10;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex - 17, false)) result[counter++] = currentIndex - 17;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex + 6 , true )) result[counter++] = currentIndex + 6 ;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex + 10, true )) result[counter++] = currentIndex + 10;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex + 15, false)) result[counter++] = currentIndex + 15;
+    if (isIndexPseudoLegalForKnight(currentIndex, currentIndex + 17, false)) result[counter++] = currentIndex + 17;
+}
 
 void extendRayIfCheckKing(
     int ray[BOARD_LENGTH], 
@@ -434,7 +434,7 @@ void calculateAttackSquares() {
     }
 }
 
-bool isKingIndexLegal(GameState currentState, int targetSquare) {
+bool isKingIndexLegal(int targetSquare) {
     // King does not land on a square which he will be eaten or does not eat one of his own square
     return !attackedSquares[targetSquare] && 
         pieceColor(pieceAtIndex(currentState.board, targetSquare)) != currentState.colorToGo;
@@ -567,7 +567,7 @@ void generateKingMoves() {
     getKingMoves(friendlyKingIndex, pseudoLegalMoves);
     for (int i = 0; i < 8; i++) {
         const int targetSquare = pseudoLegalMoves[i];
-        if (targetSquare != -1 && isKingIndexLegal(currentState, targetSquare)) {
+        if (targetSquare != -1 && isKingIndexLegal(targetSquare)) {
             appendMove(friendlyKingIndex, targetSquare, NOFlAG);
         }
     }
@@ -652,7 +652,7 @@ void appendPromotionMove(int from, int to) {
     appendMove(from, to, PROMOTE_TO_BISHOP);
 } 
 
-void checkUnPinnedEnPassant(GameState currentState, int from) {
+void checkUnPinnedEnPassant(int from) {
     // king is in the same row of a pawn, the opponent pawn who just double pawn pushed and an attacking piece
     // Board position which satisfies these criteria: 7k/8/8/KPp4r/8/8/8/8
     if ((friendlyKingIndex / 8 ) != (from / 8)) { 
@@ -747,7 +747,7 @@ void checkUnPinnedEnPassant(GameState currentState, int from) {
 
 }
 
-void generateEnPassant(GameState currentState, int from) {
+void generateEnPassant(int from) {
     if (pieceAtIndex(currentState.board, currentState.enPassantTargetSquare) != NOPIECE) { return; }
     int difference = currentState.colorToGo == WHITE ? from - currentState.enPassantTargetSquare : currentState.enPassantTargetSquare - from;
     if ((difference != 7) && (difference != 9)) { return; }
@@ -758,7 +758,7 @@ void generateEnPassant(GameState currentState, int from) {
         return;
     } 
     if (pinnedLegalMoves == NULL && !inCheck) {
-        checkUnPinnedEnPassant(currentState, from);
+        checkUnPinnedEnPassant(from);
     } else if (pinnedLegalMoves != NULL && !inCheck) {
         for (int i = 0; i < pinnedLegalMoves->count; i++) {
             if (currentState.enPassantTargetSquare == pinnedLegalMoves->items[i]) {
@@ -782,7 +782,7 @@ void generateEnPassant(GameState currentState, int from) {
     }
 }
 
-void generatePawnDoublePush(GameState currentState, int from, int increment) {
+void generatePawnDoublePush(int from, int increment) {
     if (pieceAtIndex(currentState.board, from + increment) != NOPIECE ||
         pieceAtIndex(currentState.board, from + 2 * increment) != NOPIECE) { return; }
     IntList* pinnedLegalMoves = isPieceAtLocationPinned[from];
@@ -807,7 +807,7 @@ void generatePawnDoublePush(GameState currentState, int from, int increment) {
 
 }
 
-void generateAddionnalPawnMoves(GameState currentState, int from, bool pseudoLegalMoves[BOARD_SIZE]) {
+void generateAddionnalPawnMoves(int from, bool pseudoLegalMoves[BOARD_SIZE]) {
     int increment = currentState.colorToGo == WHITE ? -8 : 8;
     bool pawnCanEnPassant = currentState.colorToGo == WHITE ? 
         from / 8 == 3 : 
@@ -816,15 +816,15 @@ void generateAddionnalPawnMoves(GameState currentState, int from, bool pseudoLeg
         from / 8 == 6 : 
         from / 8 == 1;
     if (pawnCanEnPassant && currentState.enPassantTargetSquare != -1) { 
-        generateEnPassant(currentState, from); 
+        generateEnPassant(from); 
     } else if (pawnCanDoublePush) {
-        generatePawnDoublePush(currentState, from, increment);
+        generatePawnDoublePush(from, increment);
     }
 }
 
 // Function from https://youtu.be/_vqlIPDR2TU?si=J2UVpgrqJQ3gzqCT&t=2314
 // I loved Sebastian Lague!
-void rookMoves(GameState currentState, int from) {
+void rookMoves(int from) {
     // Obtaining the blockingBitBoard
     u64 allPieceBB = allPiecesBitBoard(currentState.board);
     u64 blockingBitBoard = (allPieceBB & rookMovementMask[from]);
@@ -859,7 +859,7 @@ void rookMoves(GameState currentState, int from) {
     }
 }
 
-void bishopMoves(GameState currentState, int from) {
+void bishopMoves(int from) {
     // Obtaining the blockingBitBoard
     u64 allPieceBB = allPiecesBitBoard(currentState.board);
     u64 blockingBitBoard = (allPieceBB & bishopMovementMask[from]);
@@ -893,7 +893,7 @@ void bishopMoves(GameState currentState, int from) {
     }
 }
 
-void queenMoves(GameState currentState, int from) {
+void queenMoves(int from) {
     // Obtaining the blockingBitBoard
     u64 allPieceBB = allPiecesBitBoard(currentState.board);
     u64 rookBlockingBitBoard = (allPieceBB & rookMovementMask[from]);
@@ -931,8 +931,8 @@ void queenMoves(GameState currentState, int from) {
     }
 }
 
-void addLegalMovesFromPseudoLegalMoves(GameState currentState, int from, bool pseudoLegalMoves[BOARD_SIZE], bool isPawn, bool pawnBeforePromotion) {
-    if (isPawn) generateAddionnalPawnMoves(currentState, from, pseudoLegalMoves);
+void addLegalMovesFromPseudoLegalMoves(int from, bool pseudoLegalMoves[BOARD_SIZE], bool isPawn, bool pawnBeforePromotion) {
+    if (isPawn) generateAddionnalPawnMoves(from, pseudoLegalMoves);
     IntList* validSquaresIfPinned = isPieceAtLocationPinned[from];
     if (!inCheck && validSquaresIfPinned == NULL) {
         // King is not checked nor is the piece pinned
@@ -972,7 +972,7 @@ void addLegalMovesFromPseudoLegalMoves(GameState currentState, int from, bool ps
     }
 }
 
-void getPawnPseudoLegalMoveIndex(GameState currentState, int index, bool result[BOARD_SIZE]) {
+void getPawnPseudoLegalMoveIndex(int index, bool result[BOARD_SIZE]) {
     int potentialNeutralMove = currentState.colorToGo == WHITE ? index - 8 : index + 8;
     if (potentialNeutralMove < 0 && potentialNeutralMove > 63) {
         return;
@@ -1000,25 +1000,25 @@ void generateSupportingPiecesMoves() {
         bool pseudoLegalMoves[BOARD_SIZE] = { false };
         switch (pieceType(piece)) {
         case ROOK: 
-            rookMoves(currentState, currentIndex);
+            rookMoves(currentIndex);
         break;
         case BISHOP:
-            bishopMoves(currentState, currentIndex);
+            bishopMoves(currentIndex);
         break;
         case QUEEN:
-            queenMoves(currentState, currentIndex);
+            queenMoves(currentIndex);
         break;
         case KNIGHT:
-            getKnightPseudoLegalMoves(currentState, currentIndex, rays);
+            getKnightPseudoLegalMoves(currentIndex, rays);
             appendIntListToBoolList(rays, pseudoLegalMoves);
             resetRayResult(rays);
 
-            addLegalMovesFromPseudoLegalMoves(currentState, currentIndex, pseudoLegalMoves, false, false);
+            addLegalMovesFromPseudoLegalMoves(currentIndex, pseudoLegalMoves, false, false);
         break;
         case PAWN:
-            getPawnPseudoLegalMoveIndex(currentState, currentIndex, pseudoLegalMoves);
+            getPawnPseudoLegalMoveIndex(currentIndex, pseudoLegalMoves);
             bool isPawnBeforePromotion = currentState.colorToGo == WHITE ? currentIndex / 8 == 1 : currentIndex / 8 == 6;
-            addLegalMovesFromPseudoLegalMoves(currentState, currentIndex, pseudoLegalMoves, true, isPawnBeforePromotion);
+            addLegalMovesFromPseudoLegalMoves(currentIndex, pseudoLegalMoves, true, isPawnBeforePromotion);
             break;
         default:
             break;
@@ -1026,16 +1026,16 @@ void generateSupportingPiecesMoves() {
     }
 }
 
-bool compareGameStateForRepetition(const GameState state, const GameState gameStateToCompare) {
+bool compareGameStateForRepetition(const GameState gameStateToCompare) {
     // Comparing boards
     for (int i = 0; i < BOARD_SIZE; i++) {
-        if (pieceAtIndex(state.board, i) != pieceAtIndex(gameStateToCompare.board, i)) {
+        if (pieceAtIndex(currentState.board, i) != pieceAtIndex(gameStateToCompare.board, i)) {
             return false;
         }
     }
-    return state.castlingPerm == gameStateToCompare.castlingPerm &&
-        state.colorToGo == gameStateToCompare.colorToGo &&
-        state.enPassantTargetSquare == gameStateToCompare.enPassantTargetSquare;
+    return currentState.castlingPerm == gameStateToCompare.castlingPerm &&
+        currentState.colorToGo == gameStateToCompare.colorToGo &&
+        currentState.enPassantTargetSquare == gameStateToCompare.enPassantTargetSquare;
 }
 
 bool isThereThreeFoldRepetition(const GameState* previousStates) {
@@ -1054,7 +1054,7 @@ bool isThereThreeFoldRepetition(const GameState* previousStates) {
             break;
         }
 
-        if (compareGameStateForRepetition(currentState, previousState)) {
+        if (compareGameStateForRepetition(previousState)) {
             if (!hasOneDuplicate) {
                 hasOneDuplicate = true;
             } else {
@@ -1082,7 +1082,6 @@ void noMemoryLeaksPlease() {
     free(isPieceAtLocationPinned);
 }
 
-// TODO: Find a way to make accessible the GameState currentState variable to every function without having to pass it in arguments
 void getValidMoves(Move results[MAX_LEGAL_MOVES + 1], const GameState currentGameState, const GameState* previousStates) {
     currentState = currentGameState;
 

--- a/src/moveGenerator.c
+++ b/src/moveGenerator.c
@@ -726,28 +726,22 @@ void generateEnPassant(int from) {
 
 // TODO: Make this function use bitboards
 void generatePawnDoublePush(int from, int increment) {
+    int toSquareFromDoublePush = from + 2 * increment;
     if (pieceAtIndex(currentState.board, from + increment) != NOPIECE ||
-        pieceAtIndex(currentState.board, from + 2 * increment) != NOPIECE) { return; }
-    IntList* pinnedLegalMoves = isPieceAtLocationPinned[from];
-    if (pinnedLegalMoves != NULL && inCheck) {
-        // Pawn is pinned and the king is checked
-        return;
-    } 
-    if (pinnedLegalMoves == NULL && !inCheck) {
-        appendMove(from, from + 2 * increment, DOUBLE_PAWN_PUSH);
-    } else if (pinnedLegalMoves != NULL && !inCheck) {
-        for (int i = 0; i < pinnedLegalMoves->count; i++) {
-            if ((from + 2 * increment) == pinnedLegalMoves->items[i]) {
-                appendMove(from, from + 2 * increment, DOUBLE_PAWN_PUSH);
-                return;
-            }
-        }
-    } else if (pinnedLegalMoves == NULL && inCheck) {
-        if (protectKingSquares[from + 2 * increment]) {
-            appendMove(from, from + 2 * increment, DOUBLE_PAWN_PUSH);
-        }
-    }
+        pieceAtIndex(currentState.board, toSquareFromDoublePush) != NOPIECE) { return; }
+    
+    u64 canDoublePawnPush = (u64) 1;
+    canDoublePawnPush <<= toSquareFromDoublePush;
 
+    // Accounting for pins
+    canDoublePawnPush &= pinMasks[from];
+
+    // Accounting for checks
+    canDoublePawnPush &= checkBitBoard;
+
+    if (canDoublePawnPush) {
+        appendMove(from, toSquareFromDoublePush, DOUBLE_PAWN_PUSH);
+    }
 }
 
 void appendLegalMovesFromPseudoLegalMovesBitBoard(int from, u64 pseudoLegalMoves) {

--- a/src/moveGenerator.c
+++ b/src/moveGenerator.c
@@ -522,7 +522,7 @@ void appendIntListToBoolList(int src[BOARD_LENGTH], bool* dest) {
     }
 }
 
-void generateCastle(GameState currentState) {
+void generateCastle() {
     const int defaultKingIndex = currentState.colorToGo == WHITE ? 60 : 4;
     if (friendlyKingIndex != defaultKingIndex || inCheck) { return; }
 

--- a/src/state/Board.h
+++ b/src/state/Board.h
@@ -38,6 +38,10 @@ typedef struct Board {
    // Thus, index 6 and 7 are invalid in the array
 } Board;
 
+/**
+ * Returns the bit board of a specific piece
+*/
+u64 bitBoardForPiece(Board board, Piece piece);
 u64 whitePiecesBitBoard(Board board);
 u64 blackPiecesBitBoard(Board board);
 u64 allPiecesBitBoard(Board board);

--- a/src/state/Board.h
+++ b/src/state/Board.h
@@ -14,9 +14,9 @@ typedef struct Board {
     /* Order of the bitBoard in the array 
 
     0 -> White King
-    1 -> White Queen
-    2 -> White Knight
-    3 -> White Bishop
+    1 -> White Knight
+    2 -> White Bishop
+    3 -> White Queen
     4 -> White Rook
     5 -> White Pawn
 
@@ -24,9 +24,9 @@ typedef struct Board {
     7 -> UNUSED
 
     8 -> Black King
-    9 -> Black Queen
-    10 -> Black Knight 
-    11 -> Black Bishop
+    9 -> Black Knight 
+    10 -> Black Bishop
+    11 -> Black Queen
     12 -> Black Rook
     13 -> Black Pawn
     */

--- a/src/state/Piece.h
+++ b/src/state/Piece.h
@@ -11,14 +11,17 @@
 */
 typedef char Piece;
 
-// First 2 bits are for the color
-// Last 3 bits are for the type
+/**
+ * Note that the order of the pieces are not a coincidence
+ * The pawn, rook and queen follow one another to use a clever trick
+ * in the checkEnPassantPinned function in moveGenerator.c
+*/
 typedef enum PieceCharacteristics {
     NOPIECE = 0, 
     KING    = 1, 
-    QUEEN   = 2, 
-    KNIGHT  = 3, 
-    BISHOP  = 4, 
+    KNIGHT  = 2, 
+    BISHOP  = 3, 
+    QUEEN   = 4, 
     ROOK    = 5, 
     PAWN    = 6, 
             

--- a/src/state/Piece.h
+++ b/src/state/Piece.h
@@ -6,16 +6,11 @@
  * The piece type is in the first 3 least significant bits.
  * The piece color is the next 2 bits that follow the piece type bits
  * The first 3 most significant bits of the char are unused.
- * Use the pieceColor function or pieceType function to extract those information
- * Use the makePiece(color, type) macro to create a valid Piece
+ * Use the pieceColor(piece) function or pieceType(piece) function to extract those information
+ * Use the makePiece(color, type) function to create a valid Piece
 */
 typedef char Piece;
 
-/**
- * Note that the order of the pieces are not a coincidence
- * The pawn, rook and queen follow one another to use a clever trick
- * in the checkEnPassantPinned function in moveGenerator.c
-*/
 typedef enum PieceCharacteristics {
     NOPIECE = 0, 
     KING    = 1, 

--- a/src/state/board.c
+++ b/src/state/board.c
@@ -20,6 +20,11 @@ Piece pieceAtIndex(Board board, int index) {
                     k + q + n + b + r + p);
 }
 
+u64 bitBoardForPiece(Board board, Piece piece) {
+    int arrayIndex = piece - 9; // The best hash function there is!
+    return board.bitboards[arrayIndex];
+}
+
 u64 whitePiecesBitBoard(Board board) {
     return 
     board.bitboards[0] | 

--- a/src/state/board.c
+++ b/src/state/board.c
@@ -3,16 +3,16 @@
 Piece pieceAtIndex(Board board, int index) {
 
     Piece K = ((board.bitboards[0] >> index) & 1UL) * makePiece(WHITE, KING);
-    Piece Q = ((board.bitboards[1] >> index) & 1UL) * makePiece(WHITE, QUEEN);
-    Piece N = ((board.bitboards[2] >> index) & 1UL) * makePiece(WHITE, KNIGHT);
-    Piece B = ((board.bitboards[3] >> index) & 1UL) * makePiece(WHITE, BISHOP);
+    Piece N = ((board.bitboards[1] >> index) & 1UL) * makePiece(WHITE, KNIGHT);
+    Piece B = ((board.bitboards[2] >> index) & 1UL) * makePiece(WHITE, BISHOP);
+    Piece Q = ((board.bitboards[3] >> index) & 1UL) * makePiece(WHITE, QUEEN);
     Piece R = ((board.bitboards[4] >> index) & 1UL) * makePiece(WHITE, ROOK);
     Piece P = ((board.bitboards[5] >> index) & 1UL) * makePiece(WHITE, PAWN);
 
-    Piece k = ((board.bitboards[8] >> index) & 1UL) * makePiece(BLACK, KING);
-    Piece q = ((board.bitboards[9] >> index) & 1UL) * makePiece(BLACK, QUEEN);
-    Piece n = ((board.bitboards[10] >> index) & 1UL) * makePiece(BLACK, KNIGHT);
-    Piece b = ((board.bitboards[11] >> index) & 1UL) * makePiece(BLACK, BISHOP);
+    Piece k = ((board.bitboards[8 ] >> index) & 1UL) * makePiece(BLACK, KING);
+    Piece n = ((board.bitboards[9 ] >> index) & 1UL) * makePiece(BLACK, KNIGHT);
+    Piece b = ((board.bitboards[10] >> index) & 1UL) * makePiece(BLACK, BISHOP);
+    Piece q = ((board.bitboards[11] >> index) & 1UL) * makePiece(BLACK, QUEEN);
     Piece r = ((board.bitboards[12] >> index) & 1UL) * makePiece(BLACK, ROOK);
     Piece p = ((board.bitboards[13] >> index) & 1UL) * makePiece(BLACK, PAWN);
 
@@ -32,8 +32,8 @@ u64 whitePiecesBitBoard(Board board) {
 
 u64 blackPiecesBitBoard(Board board) {
     return 
-    board.bitboards[8] | 
-    board.bitboards[9] |
+    board.bitboards[8 ] | 
+    board.bitboards[9 ] |
     board.bitboards[10] | 
     board.bitboards[11] |
     board.bitboards[12] | 

--- a/src/utils/fenString.c
+++ b/src/utils/fenString.c
@@ -6,8 +6,8 @@
 
 int getCastlingPermFromFenString(char* fen) {
     int result = 0;
-    if (strcmp(fen,"-") == 0) return result;
-    for (int i = 0; i < strlen(fen); i++) {
+    if (strcmp(fen, "-") == 0) return result;
+    for (size_t i = 0; i < strlen(fen); i++) {
         char c = fen[i];
         if (c == 'K') {
             result |= (1 << 3);
@@ -24,7 +24,7 @@ int getCastlingPermFromFenString(char* fen) {
 
 void setBoardArrayFromFenString(char* fen, Piece* board) {
   int row = 0, col = 0;
-  for (int i = 0; i < strlen(fen); i++) {
+  for (size_t i = 0; i < strlen(fen); i++) {
     char fenChar = fen[i];
     if (fenChar == '/') {
       row++;
@@ -98,6 +98,10 @@ do { \
 */
 bool setGameStateFromFenString(char *fen, GameState* result) {
     if (result == NULL) { return false; }
+    if (strlen(fen) > 100) {
+      printf("The fen string length is bigger than 100, which is too long for the program\n");
+      return false;
+    }
     char copy[100]; // Could have potential buffer overflow
     strcpy(copy, fen);
     char* split = strtok(copy, " ");

--- a/testing/perft.c
+++ b/testing/perft.c
@@ -74,6 +74,12 @@ bool isStringValidPerftNumber(char* string) {
   return result;
 }
 
+// k6r/8/8/K1Pp4/8/8/8/8 w - d6 0 1 (Normal en-passant)
+// r7/7k/8/K1pP4/8/8/8/8 w - c6 0 1 (King is in check but en-passant is possible)
+// r3b3/7k/8/2pP4/1K6/8/8/2rb4 w - c6 0 1 (king is in check and en-passant will remove the check)
+// k7/b7/8/2Pp4/3K4/8/8/8 w - d6 0 1 (Pawn is pinned but en-passant is possible)
+// k7/8/8/K1Pp3r/8/8/8/8 w - d6 0 1 (Pawn is en-passant pinned)
+// TODO: Add a test functionnality for the perft program
 // To compile and run the program: ./perft <depth>
 // To check for memory leaks that program: valgrind --leak-check=full --track-origins=yes -s ./perftTesting <depth>
 int main(int argc, char* argv[]) {
@@ -129,6 +135,7 @@ int main(int argc, char* argv[]) {
   u64 perftResult;
 
   if (debug) {
+    printBoard(startingState.board);
     perftResult = perft(maximumDepth);
     printf("Perft depth %d returned a total number of moves of %lu\n", maximumDepth, perftResult);
   } else {

--- a/testing/perft.c
+++ b/testing/perft.c
@@ -90,6 +90,8 @@ r7/7k/8/K1pP4/8/8/8/8 w - c6 0 1 (King is in check but en-passant is possible)
 r3b3/7k/8/2pP4/1K6/8/8/2rb4 w - c6 0 1 (king is in check and en-passant will remove the check)
 k7/b7/8/2Pp4/3K4/8/8/8 w - d6 0 1 (Pawn is pinned but en-passant is possible)
 k7/8/8/K1Pp3r/8/8/8/8 w - d6 0 1 (Pawn is en-passant pinned)
+8/8/3p4/KPp4r/1R2PpPk/8/8/ b - e3 0 1 (Pawn looks like it is en-passant pinned but it isn't) (ans: 16)
+8/8/8/KPpP3r/1R3p1k/8/6P1/ w - c6 1 3 (Two pawns look en-passant pinned but both can do en-passant) (ans: 17)
 
 */
 

--- a/testing/perft.c
+++ b/testing/perft.c
@@ -64,7 +64,7 @@ bool isStringValidPerftNumber(char* string) {
   int index = 0;
   char currentChar;
   bool result = true;
-  while (currentChar = *(string + index)) {
+  while ((currentChar = *(string + index))) {
     if (currentChar < '0' || currentChar > '9') {
       result = false;
       break;

--- a/testing/perft.c
+++ b/testing/perft.c
@@ -23,7 +23,6 @@ u64 perft(int depth) {
   GameState previousStates[1] = { 0 };
   
   Move moves[MAX_LEGAL_MOVES + 1] = { [0 ... (MAX_LEGAL_MOVES)] = 0 };
-
   getValidMoves(moves, previousState, previousStates); // We do not care about draw by repetition
   int nbOfMoves, i;
   u64 nodes = 0;
@@ -61,7 +60,19 @@ u64 perft(int depth) {
   return nodes;
 }
 
-// "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"
+bool isStringValidPerftNumber(char* string) {
+  int index = 0;
+  char currentChar;
+  bool result = true;
+  while (currentChar = *(string + index)) {
+    if (currentChar < '0' || currentChar > '9') {
+      result = false;
+      break;
+    }
+    index++;
+  }
+  return result;
+}
 
 // To compile and run the program: ./perft <depth>
 // To check for memory leaks that program: valgrind --leak-check=full --track-origins=yes -s ./perftTesting <depth>
@@ -69,14 +80,17 @@ int main(int argc, char* argv[]) {
   if (argc == 1) {
     printf("Usage: ./%s <depth (num)> [position (fen string)] [mode (debug or time)]\n", argv[0]);
     printf("Note that order does not matter for `position` and `mode` arguments, and they are optional\n");
-    return 0;
+    exit(EXIT_FAILURE);
   }
 
-  maximumDepth = atoi(argv[1]);
-
+  if (isStringValidPerftNumber(argv[1])) {
+    maximumDepth = atoi(argv[1]);
+  } else {
+    printf("Argument %s is not a valid digit\n", argv[1]);
+  } 
   if (maximumDepth <= 0) {
     printf("Invalid depth %d\n", maximumDepth);
-    return 0;
+    exit(EXIT_FAILURE);
   }
 
   // The default is the starting fen string
@@ -107,7 +121,7 @@ int main(int argc, char* argv[]) {
   
   if (!setGameStateFromFenString(fenString, &startingState)) {
     printf("The fen string \"%s\" is invalid!\n", fenString);
-    return 1;
+    exit(EXIT_FAILURE);
   }
 
   achievedStates[0] = startingState;

--- a/testing/perft.c
+++ b/testing/perft.c
@@ -74,13 +74,27 @@ bool isStringValidPerftNumber(char* string) {
   return result;
 }
 
-// k6r/8/8/K1Pp4/8/8/8/8 w - d6 0 1 (Normal en-passant)
-// r7/7k/8/K1pP4/8/8/8/8 w - c6 0 1 (King is in check but en-passant is possible)
-// r3b3/7k/8/2pP4/1K6/8/8/2rb4 w - c6 0 1 (king is in check and en-passant will remove the check)
-// k7/b7/8/2Pp4/3K4/8/8/8 w - d6 0 1 (Pawn is pinned but en-passant is possible)
-// k7/8/8/K1Pp3r/8/8/8/8 w - d6 0 1 (Pawn is en-passant pinned)
+/* Testing all the double pawn push case
+
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 (Normal double pawn push) (ans: 20)
+2r4k/8/8/8/3p4/8/2P5/2K5 w - - 0 1 (Pawn is pinned but still can double pawn push) (ans: 6)
+7k/8/8/8/3p4/8/r1P1K3/8 w - - 0 1 (Pawn is pinned and cannot double pawn push) (ans: 7)
+7k/8/8/4b3/8/8/3P4/K7 w - - 0 1 (King is in check and pawn can double push to get out of check) (ans: 3)
+
+*/
+
+/* Testing all the en-passant case
+
+k6r/8/8/K1Pp4/8/8/8/8 w - d6 0 1 (Normal en-passant)
+r7/7k/8/K1pP4/8/8/8/8 w - c6 0 1 (King is in check but en-passant is possible)
+r3b3/7k/8/2pP4/1K6/8/8/2rb4 w - c6 0 1 (king is in check and en-passant will remove the check)
+k7/b7/8/2Pp4/3K4/8/8/8 w - d6 0 1 (Pawn is pinned but en-passant is possible)
+k7/8/8/K1Pp3r/8/8/8/8 w - d6 0 1 (Pawn is en-passant pinned)
+
+*/
+
 // TODO: Add a test functionnality for the perft program
-// To compile and run the program: ./perft <depth>
+// To compile and run the program: ./perft
 // To check for memory leaks that program: valgrind --leak-check=full --track-origins=yes -s ./perftTesting <depth>
 int main(int argc, char* argv[]) {
   if (argc == 1) {
@@ -111,11 +125,11 @@ int main(int argc, char* argv[]) {
     }
   }
   if (argc >= 4) {
-    char* secondArg = argv[3];
-    if (strcmp(secondArg, "time") == 0) {
+    char* thirdArg = argv[3];
+    if (strcmp(thirdArg, "time") == 0) {
       debug = false;
-    } else if (strcmp(secondArg, "debug")) {
-      fenString = secondArg;
+    } else if (strcmp(thirdArg, "debug")) {
+      fenString = thirdArg;
     }
   }
 


### PR DESCRIPTION
I revamped the entirety of the code in the moveGenerator.c file to make use of bit boards. The calculation of attacked squares by enemy pieces, the handling of pins and checks, and the generation of legal moves of all pieces now utilize bit boards. This resulted in a non-negligible speedup in the move generation. While rewriting, I removed many functions that were either badly written or were now made obsolete because of bit boards.